### PR TITLE
Update `wiremock` and `jetty`.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,11 +52,11 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')
     testImplementation('org.junit.jupiter:junit-jupiter-params:5.3.1')
-    testImplementation('com.github.tomakehurst:wiremock:2.27.2')
+    testImplementation('com.github.tomakehurst:wiremock:3.0.0-beta-2')
     testImplementation('org.mockito:mockito-core:2.23.0')
     testImplementation('org.junit.jupiter:junit-jupiter-engine:5.3.1')
     testImplementation('org.junit-pioneer:junit-pioneer:0.3.0')
-    testImplementation('org.eclipse.jetty:jetty-server:9.2.24.v20180105')
+    testImplementation('org.eclipse.jetty:jetty-server:11.0.12')
 
     // Enforce wiremock to use latest guava and json-smart
     testImplementation('com.google.guava:guava:31.1-jre')


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yury.fridlyand@improving.com>

### Description
Update `wiremock` and `jetty` which `wiremock` depends on.
Wiremock release: https://github.com/wiremock/wiremock/releases/tag/3.0.0-beta-2
Maven: https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock/3.0.0-beta-2
Previous update: https://github.com/opensearch-project/sql/pull/872
Newer `jetty` activates SNI check, so I had to disable it, [ref](https://stackoverflow.com/questions/69945173/http-error-400-invalid-sni-jetty-https-servlet): https://github.com/Bit-Quill/sql-jdbc/blob/c3a79b79d58665d8fd3b69167c9a8fa9601a0467/src/test/java/org/opensearch/jdbc/test/TLSServer.java#L88-L90
 
### Issues Resolved
https://github.com/opensearch-project/sql-jdbc/issues/8
https://github.com/opensearch-project/sql-jdbc/issues/7
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).