### PR TITLE
Preemptive Authentication POC

### DIFF
--- a/src/main/java/org/opensearch/jdbc/config/ConnectionConfig.java
+++ b/src/main/java/org/opensearch/jdbc/config/ConnectionConfig.java
@@ -46,6 +46,7 @@ public class ConnectionConfig {
     private String trustStoreType;
     private boolean trustSelfSigned;
     private boolean hostnameVerification;
+    private boolean usePreemptiveAuth;
 
     private ConnectionConfig(Builder builder) {
         this.url = builder.getUrl();
@@ -80,6 +81,8 @@ public class ConnectionConfig {
         this.trustSelfSigned = builder.getTrustSelfSignedConnectionProperty().getValue();
 
         this.hostnameVerification = builder.getHostnameVerificationConnectionProperty().getValue();
+
+        this.usePreemptiveAuth = builder.getUsePreemptiveAuthConnectionProperty().getValue();
     }
 
     public static Builder builder() {
@@ -182,6 +185,10 @@ public class ConnectionConfig {
         return hostnameVerification;
     }
 
+    public boolean usePreemptiveAuth() {
+        return usePreemptiveAuth;
+    }
+
     @Override
     public String toString() {
         return "ConnectionConfig{" +
@@ -209,6 +216,7 @@ public class ConnectionConfig {
                 ", trustStoreType='" + trustStoreType + '\'' +
                 ", trustSelfSigned='" + trustSelfSigned + '\'' +
                 ", hostnameVerification='" + hostnameVerification + '\'' +
+                ", usePreemptiveAuth='" + usePreemptiveAuth + '\'' +
                 '}';
     }
 
@@ -256,6 +264,9 @@ public class ConnectionConfig {
         private HostnameVerificationConnectionProperty hostnameVerificationConnectionProperty
                 = new HostnameVerificationConnectionProperty();
 
+        private UsePreemptiveAuthProperty usePreemptiveAuthConnectionProperty
+                = new UsePreemptiveAuthProperty();
+
         ConnectionProperty[] connectionProperties = new ConnectionProperty[]{
                 hostProperty,
                 portProperty,
@@ -278,7 +289,8 @@ public class ConnectionConfig {
                 trustStorePasswordConnectionProperty,
                 trustStoreTypeConnectionProperty,
                 trustSelfSignedConnectionProperty,
-                hostnameVerificationConnectionProperty
+                hostnameVerificationConnectionProperty,
+                usePreemptiveAuthConnectionProperty
         };
 
         private String url = null;
@@ -383,6 +395,10 @@ public class ConnectionConfig {
 
         public HostnameVerificationConnectionProperty getHostnameVerificationConnectionProperty() {
             return hostnameVerificationConnectionProperty;
+        }
+
+        public UsePreemptiveAuthProperty getUsePreemptiveAuthConnectionProperty() {
+            return usePreemptiveAuthConnectionProperty;
         }
 
         public Builder setLogWriter(PrintWriter printWriter) {

--- a/src/main/java/org/opensearch/jdbc/config/UsePreemptiveAuthProperty.java
+++ b/src/main/java/org/opensearch/jdbc/config/UsePreemptiveAuthProperty.java
@@ -15,6 +15,6 @@ public class UsePreemptiveAuthProperty extends BoolConnectionProperty {
 
     @Override
     public Boolean getDefault() {
-        return true;
+        return false;
     }
 }

--- a/src/main/java/org/opensearch/jdbc/config/UsePreemptiveAuthProperty.java
+++ b/src/main/java/org/opensearch/jdbc/config/UsePreemptiveAuthProperty.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.jdbc.config;
+
+public class UsePreemptiveAuthProperty extends BoolConnectionProperty {
+    public static final String KEY = "usePreemptiveAuth";
+
+    public UsePreemptiveAuthProperty() {
+        super(KEY);
+    }
+
+    @Override
+    public Boolean getDefault() {
+        return true;
+    }
+}

--- a/src/main/java/org/opensearch/jdbc/transport/http/ApacheHttpTransport.java
+++ b/src/main/java/org/opensearch/jdbc/transport/http/ApacheHttpTransport.java
@@ -111,6 +111,8 @@ public class ApacheHttpTransport implements HttpTransport, LoggingSource {
             basicCredsProvider.setCredentials(
                     AuthScope.ANY,
                     new UsernamePasswordCredentials(connectionConfig.getUser(), connectionConfig.getPassword()));
+
+            // sets the credentials for authentication on the first request
             if (connectionConfig.usePreemptiveAuth()) {
                 this.preemptiveCreds = basicCredsProvider.getCredentials(AuthScope.ANY);
             }

--- a/src/main/java/org/opensearch/jdbc/transport/http/ApacheHttpTransport.java
+++ b/src/main/java/org/opensearch/jdbc/transport/http/ApacheHttpTransport.java
@@ -6,6 +6,9 @@
 
 package org.opensearch.jdbc.transport.http;
 
+import org.apache.http.auth.AuthenticationException;
+import org.apache.http.auth.Credentials;
+import org.apache.http.impl.auth.BasicScheme;
 import org.opensearch.jdbc.auth.AuthenticationType;
 import org.opensearch.jdbc.config.ConnectionConfig;
 import org.opensearch.jdbc.logging.Logger;
@@ -64,12 +67,14 @@ public class ApacheHttpTransport implements HttpTransport, LoggingSource {
 
     private RequestConfig requestConfig;
     private CloseableHttpClient httpClient;
+    private Credentials preemptiveCreds;
 
     public ApacheHttpTransport(ConnectionConfig connectionConfig, Logger log, String userAgent) throws TransportException {
         this.host = connectionConfig.getHost();
         this.port = connectionConfig.getPort();
         this.scheme = connectionConfig.isUseSSL() ? "https" : "http";
         this.path = connectionConfig.getPath();
+        this.preemptiveCreds = null;
 
         updateRequestConfig();
 
@@ -106,6 +111,9 @@ public class ApacheHttpTransport implements HttpTransport, LoggingSource {
             basicCredsProvider.setCredentials(
                     AuthScope.ANY,
                     new UsernamePasswordCredentials(connectionConfig.getUser(), connectionConfig.getPassword()));
+            if (connectionConfig.usePreemptiveAuth()) {
+                this.preemptiveCreds = basicCredsProvider.getCredentials(AuthScope.ANY);
+            }
             httpClientBuilder.setDefaultCredentialsProvider(basicCredsProvider);
 
         } else if (connectionConfig.getAuthenticationType() == AuthenticationType.AWS_SIGV4) {
@@ -239,8 +247,12 @@ public class ApacheHttpTransport implements HttpTransport, LoggingSource {
             HttpGet request = new HttpGet(uri);
             request.setHeaders(headers);
             request.setConfig(getRequestConfig());
+
+            if (this.preemptiveCreds != null) {
+                request.addHeader(new BasicScheme().authenticate(this.preemptiveCreds, request, null));
+            }
             return httpClient.execute(request);
-        } catch (IOException e) {
+        } catch (IOException | AuthenticationException e) {
             throw new TransportException(e);
         }
     }


### PR DESCRIPTION
### Description
Created a new driver connection property to set preemptive authentication to work with SAML authentication. Authentication is set to non-preemptive by default and can be changed by setting `usePreemptiveAuth` to `true`.
 
### Issues Resolved
https://github.com/opensearch-project/sql-jdbc/issues/28
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).