### PR TITLE
Removed h2 as a dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,6 @@ dependencies {
         include '*.jar'
         builtBy 'compileJdbc'
     }
-    testImplementation group: 'com.h2database', name: 'h2', version: '2.1.210'
     testImplementation group: 'org.xerial', name: 'sqlite-jdbc', version: '3.41.2.2'
     testImplementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
 }


### PR DESCRIPTION
### Description
H2 is included but not used and makes CI fail.
 
### Issues Resolved
https://github.com/opensearch-project/sql-jdbc/issues/5
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).