### PR TITLE
Made driver throw SQLSTATE 28000 for invalid username or password

### DIFF
--- a/src/main/java/org/opensearch/jdbc/ConnectionImpl.java
+++ b/src/main/java/org/opensearch/jdbc/ConnectionImpl.java
@@ -58,7 +58,7 @@ public class ConnectionImpl implements OpenSearchConnection, JdbcWrapper, Loggin
     private ClusterMetadata clusterMetadata;
     // 28000 is the SQLSTATE for invalid authorization specification
     // https://docs.oracle.com/cd/E15817_01/appdev.111/b31228/appd.htm
-    private final String incorrectCredentialsSQLState = "28000";
+    private final String INCORRECT_CREDENTIALS_SQLSTATE = "28000";
 
     public ConnectionImpl(ConnectionConfig connectionConfig, Logger log) throws SQLException {
         this(connectionConfig, ApacheHttpTransportFactory.INSTANCE, JsonHttpProtocolFactory.INSTANCE, log);
@@ -89,7 +89,7 @@ public class ConnectionImpl implements OpenSearchConnection, JdbcWrapper, Loggin
             this.open = true;
         } catch (HttpException ex) {
             logAndThrowSQLException(log, new SQLException("Connection error " + ex.getMessage(),
-                incorrectCredentialsSQLState, ex));
+                INCORRECT_CREDENTIALS_SQLSTATE, ex));
         } catch (ResponseException | IOException ex) {
             logAndThrowSQLException(log, new SQLException("Connection error " + ex.getMessage(), ex));
         }

--- a/src/main/java/org/opensearch/jdbc/ConnectionImpl.java
+++ b/src/main/java/org/opensearch/jdbc/ConnectionImpl.java
@@ -59,8 +59,6 @@ public class ConnectionImpl implements OpenSearchConnection, JdbcWrapper, Loggin
     // https://docs.oracle.com/cd/E15817_01/appdev.111/b31228/appd.htm
     // 28000 is the SQLSTATE for invalid authorization specification
     private final String INCORRECT_CREDENTIALS_SQLSTATE = "28000";
-    // 08001 is the SQLSTATE for failing to establish connection
-    private final String FAILED_TO_ESTABLISH_SQL_CONNECTION = "08001";
 
     public ConnectionImpl(ConnectionConfig connectionConfig, Logger log) throws SQLException {
         this(connectionConfig, ApacheHttpTransportFactory.INSTANCE, JsonHttpProtocolFactory.INSTANCE, log);
@@ -94,12 +92,10 @@ public class ConnectionImpl implements OpenSearchConnection, JdbcWrapper, Loggin
                 logAndThrowSQLException(log, new SQLException("Connection error " + ex.getMessage(),
                     INCORRECT_CREDENTIALS_SQLSTATE, ex));
             } else {
-                logAndThrowSQLException(log, new SQLException("Connection error " + ex.getMessage(),
-                    FAILED_TO_ESTABLISH_SQL_CONNECTION, ex));
+                logAndThrowSQLException(log, new SQLException("Connection error " + ex.getMessage(), ex));
             }
         } catch (ResponseException | IOException ex) {
-            logAndThrowSQLException(log, new SQLException("Connection error " + ex.getMessage(),
-                FAILED_TO_ESTABLISH_SQL_CONNECTION, ex));
+            logAndThrowSQLException(log, new SQLException("Connection error " + ex.getMessage(), ex));
         }
 
     }


### PR DESCRIPTION
### Description
This change throws SQLSTATE 28000 for invalid username or password which is [required by Tableau](https://tableau.github.io/connector-plugin-sdk/docs/manual-test#:~:text=Connect%20to%20the%20correct%20database%20with%20the%20wrong%20credentials). This only covers 401 responses, responses like 403 from SIGV4 returns a different message.

Before:
<img width="548" alt="Screenshot 2023-06-15 at 11 20 50 AM" src="https://github.com/opensearch-project/sql-jdbc/assets/29149268/cf00a8d9-c573-45bf-b6b1-c880f28db6fe">

After:
<img width="548" alt="Screenshot 2023-06-21 at 3 30 51 PM" src="https://github.com/Bit-Quill/sql-jdbc/assets/29149268/4f12f5cf-980b-43e6-a9c7-6f9dc8d3760f">
 
### Issues Resolved
https://github.com/opensearch-project/sql-jdbc/issues/95
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).